### PR TITLE
Strict Standards requires identical parent method signature

### DIFF
--- a/mediawiki-skin/freifunk/Freifunk.php
+++ b/mediawiki-skin/freifunk/Freifunk.php
@@ -17,7 +17,7 @@ if( !defined( 'MEDIAWIKI' ) )
  */
 class SkinFreifunk extends SkinTemplate {
 	/** Using freifunk. */
-	function initPage( &$out ) {
+	function initPage( OuputPage $out ) {
 		SkinTemplate::initPage( $out );
 		$this->skinname  = 'freifunk';
 		$this->stylename = 'freifunk';


### PR DESCRIPTION
fixes

Strict Standards:  Declaration of SkinFreifunk::initPage() should be
compatible with Skin::initPage(OutputPage $out) in
skins/freifunk/Freifunk.php on line 18
